### PR TITLE
Issue #22: Dynamically allocate MIDIPacketLists to ensure space for all ...

### DIFF
--- a/Source/MIKMIDICommand.h
+++ b/Source/MIKMIDICommand.h
@@ -193,14 +193,16 @@ typedef NS_ENUM(NSUInteger, MIKMIDICommandType) {
 @end
 
 /**
- *  Returns (by reference) a CoreMIDI MIDIPacketList created from an array of MIKMIDICommand instances.
+ *  Allocates and returns (by reference) a CoreMIDI MIDIPacketList created from an array of MIKMIDICommand instances.
+ *  The created MIDIPacketList will be sized according to the number of commands and their contents. Ownership is
+ *  transfered to the caller which becomes responsible for freeing the allocated memory.
  *  Used by MIKMIDI when sending commands. Typically, this is not needed by clients of MIKMIDI.
  *
- *  @param inOutPacketList A pointer to a MIDIPacketList structure.
- *  @param listSize        The size in bytes of the MIDIPacketList, or 0 to use sizeof() (ie. only a single command).
+ *  @param outPacketList   A pointer pointer to a MIDIPacketList structure which will point to the created MIDIPacketList
+ *                         upon success.
  *  @param commands        An array of MIKMIDICommand instances.
  *
  *  @return YES if creating the packet list was successful, NO if an error occurred.
  */
-BOOL MIKMIDIPacketListFromCommands(MIDIPacketList *inOutPacketList, ByteCount listSize, NSArray *commands);
+BOOL MIKCreateMIDIPacketListFromCommands(MIDIPacketList **outPacketList, NSArray *commands);
 

--- a/Source/MIKMIDIOutputPort.m
+++ b/Source/MIKMIDIOutputPort.m
@@ -38,10 +38,11 @@
 	
 	error = error ? error : &(NSError *__autoreleasing){ nil };
 
-	MIDIPacketList packetList;
-	if (!MIKMIDIPacketListFromCommands(&packetList, 0, commands)) return NO;
+	MIDIPacketList *packetList;
+	if (!MIKCreateMIDIPacketListFromCommands(&packetList, commands)) return NO;
 	
-	OSStatus err = MIDISend(self.portRef, destination.objectRef, &packetList);
+	OSStatus err = MIDISend(self.portRef, destination.objectRef, packetList);
+	free(packetList);
 	if (err != noErr) {
 		*error = [NSError errorWithDomain:NSOSStatusErrorDomain code:err userInfo:nil];
 		return NO;


### PR DESCRIPTION
...commands.

The previous code directly used stack allocation of the defined MIDIPacketList
structure. This default structure only allows for 256 data bytes. If an array of
MIKMIDICommands was sent that required more space an error would occur.

The fix is to make MIKMIDIPacketListFromCommands dynamically allocate the
appropriate amount of memory by computing the needed size and returning a
reference through a pointer parameter. These changes do modify the signature of
MIKMIDIPacketListFromCommands so any uses outside of MIKMIDICommand must be
updated.
