### PR TITLE
Removing computed properties that don't have setters

### DIFF
--- a/Source/MIKMIDINoteEvent.h
+++ b/Source/MIKMIDINoteEvent.h
@@ -89,10 +89,6 @@
 @property (nonatomic, readwrite) UInt8 channel;
 @property (nonatomic, readwrite) UInt8 releaseVelocity;
 @property (nonatomic, readwrite) Float32 duration;
-@property (nonatomic, readwrite) MusicTimeStamp endTimeStamp;
-@property (nonatomic, readwrite) float frequency;
-@property (nonatomic, readwrite) NSString *noteLetter;
-@property (nonatomic, readwrite) NSString *noteLetterAndOctave;
 
 @end
 

--- a/Source/MIKMIDINoteEvent.m
+++ b/Source/MIKMIDINoteEvent.m
@@ -145,17 +145,13 @@
 
 @implementation MIKMutableMIDINoteEvent
 
+@dynamic timeStamp;
+@dynamic data;
 @dynamic note;
 @dynamic velocity;
 @dynamic channel;
 @dynamic releaseVelocity;
 @dynamic duration;
-@dynamic endTimeStamp;
-@dynamic frequency;
-@dynamic noteLetter;
-@dynamic noteLetterAndOctave;
-@dynamic timeStamp;
-@dynamic data;
 
 + (BOOL)isMutable { return YES; }
 


### PR DESCRIPTION
I made setters in my last PR for some computed properties on MIKMIDINoteEvent. Went through the rest of the events to check the same thing but the note event appeared to be the only one with computed properties.