### PR TITLE
Warn when attempting to insert NULL or unknown eventType.

### DIFF
--- a/Source/MIKMIDITrack.m
+++ b/Source/MIKMIDITrack.m
@@ -76,6 +76,7 @@
 
     switch (event.eventType) {
         case kMusicEventType_NULL:
+            NSLog(@"Warning: insertMIDITrack: attempted to insert NULL event.");
             break;
 
         case kMusicEventType_ExtendedNote:
@@ -122,6 +123,9 @@
             err = MusicTrackNewAUPresetEvent(track, timeStamp, data);
             if (err) NSLog(@"MusicTrackNewAUPresetEvent() failed with error %d in %s.", err, __PRETTY_FUNCTION__);
             break;
+        default:
+            err = 1;
+            NSLog(@"Warning: insertMIDIEvent: attempted to insert unknown event type %d.", event.eventType);
     }
 
     return !err;


### PR DESCRIPTION
Mostly raising this for discussion, but it turns out that all subclasses create with a type of NULL since no subclasses of MIKMIDIEvent implement any constructors (see #59). That took me a bit to figure out because MIKMIDITrack ignores NULL eventTypes, so these warnings would have been helpful. I'm not sure if the `default` is necessary, or if a `NULL` event is very common/acceptable in a "correct" MIDI file (warning could be annoying if `NULL` doesn't necessarily indicate something is wrong) but I'm not familiar enough with MIDI to make a call on that.