### PR TITLE
Fix setChannel to set the channel on newly created MIDI commands.

### DIFF
--- a/Source/MIKMIDIChannelVoiceCommand.m
+++ b/Source/MIKMIDIChannelVoiceCommand.m
@@ -70,7 +70,7 @@
 	if ([self.internalData length] < 2) [self.internalData increaseLengthBy:2-[self.internalData length]];
 	
 	UInt8 *data = (UInt8 *)[self.internalData mutableBytes];
-	data[0] &= 0xF0 | (channel & 0x0F);
+	data[0] = (0xF0 & data[0]) | (channel & 0x0F);
 }
 
 - (NSUInteger)value { return self.dataByte2 & 0x7F; }


### PR DESCRIPTION
`MIKMIDIChannelVoiceCommand`'s `setChannel` method performs binary arithmetic intended to set the second byte of the MIDI packet to the channel number. However, the arithmetic doesn't actually set the channel number - it takes a binary AND of the existing first data byte and `0xF?`, where `?` is the new channel number. As the second nibble of the byte is zero if the `MIKMIDIChannelVoiceCommand` was just initialized, this results in `data[0]` being set to `0xF? & 0x?0`, resulting in a `data[0]` value whose second nibble - and thus whose channel - is always 0.

This PR fixes that by keeping the first nibble of the existing byte, then replacing the second nibble with the new channel number.