### PR TITLE
Fix channel voice command types

### DIFF
--- a/Source/MIKMIDIChannelVoiceCommand.m
+++ b/Source/MIKMIDIChannelVoiceCommand.m
@@ -110,7 +110,7 @@
 	if ([self.internalData length] < 2) [self.internalData increaseLengthBy:2-[self.internalData length]];
 	
 	UInt8 *data = (UInt8 *)[self.internalData mutableBytes];
-	data[0] &= 0x0F | (commandType & 0xF0); // Need to avoid changing channel
+    data[0] = (0xF0 & commandType) | (data[0] & 0x0F);
 }
 
 @end


### PR DESCRIPTION
This is basically the same change as https://github.com/mixedinkey-opensource/MIKMIDI/commit/73bf54995b5a4378e13176a93aaf1e609f3139d9, except for setting the command type.