### PR TITLE
Issue #109: Refactor MIKMIDIInputPort.

### DIFF
--- a/Source/MIKMIDICompilerCompatibility.h
+++ b/Source/MIKMIDICompilerCompatibility.h
@@ -22,10 +22,18 @@
 
 #ifndef MIKArrayOf
 #if __has_feature(objc_generics)
+
 #define MIKArrayOf(TYPE) NSArray<TYPE>
 #define MIKArrayOfKindOf(TYPE) NSArray<__kindof TYPE>
+
+#define MIKMapTableOf(KEYTYPE, OBJTYPE) NSMapTable<KEYTYPE, OBJTYPE>
+
 #else
+
 #define MIKArrayOf(TYPE) NSArray
 #define MIKArrayOfKindOf(TYPE) NSArray
+
+#define MIKMapTableOf(KEYTYPE, OBJTYPE) NSMapTable
+
 #endif
 #endif // #ifndef MIKArrayOf

--- a/Source/MIKMIDIDeviceManager.h
+++ b/Source/MIKMIDIDeviceManager.h
@@ -92,10 +92,9 @@ extern NSString * const MIKMIDIEndpointKey;
  *  must be a token previously returned by -connectInput:error:eventHandler:. Only the
  *  event handler block passed into the call that returned the token will be disconnected.
  *
- *  @param endpoint        The MIKMIDISourceEndpoint instance from which to disconnect.
  *  @param connectionToken The connection token returned by -connectInput:error:eventHandler: when the input was connected.
  */
-- (void)disconnectInput:(MIKMIDISourceEndpoint *)endpoint forConnectionToken:(id)connectionToken;
+- (void)disconnectConnectionforToken:(id)connectionToken;
 
 /**
  *  Used to send MIDI messages/commands from your application to a MIDI output endpoint. 
@@ -166,6 +165,22 @@ extern NSString * const MIKMIDIEndpointKey;
  *  An NSArray of MIKMIDISourceEndpoint instances that are connected to at least one event handler.
  */
 @property (nonatomic, readonly) MIKArrayOf(MIKMIDISourceEndpoint *) *connectedInputSources;
+
+@end
+
+@interface MIKMIDIDeviceManager (Deprecated)
+
+/**
+ *  @deprecated Use disconnectConnectionforToken: instead. This method now simply calls through to that one.
+ *
+ *  Disconnects a previously connected MIDI input/source endpoint. The connectionToken argument
+ *  must be a token previously returned by -connectInput:error:eventHandler:. Only the
+ *  event handler block passed into the call that returned the token will be disconnected.
+ *
+ *  @param endpoint        This argument is ignored.
+ *  @param connectionToken The connection token returned by -connectInput:error:eventHandler: when the input was connected.
+ */
+- (void)disconnectInput:(nullable MIKMIDISourceEndpoint *)endpoint forConnectionToken:(id)connectionToken DEPRECATED_ATTRIBUTE;
 
 @end
 

--- a/Source/MIKMIDIEndpointSynthesizer.m
+++ b/Source/MIKMIDIEndpointSynthesizer.m
@@ -95,7 +95,7 @@
 {
 	if (_endpoint) {
 		if ([_endpoint isKindOfClass:[MIKMIDISourceEndpoint class]]) {
-			[[MIKMIDIDeviceManager sharedDeviceManager] disconnectInput:(MIKMIDISourceEndpoint *)self.endpoint forConnectionToken:self.connectionToken];
+			[[MIKMIDIDeviceManager sharedDeviceManager] disconnectConnectionforToken:self.connectionToken];
 		}
 		// Don't need to do anything for a destination endpoint. __weak reference in the messages handler will automatically nil out.
 	}

--- a/Source/MIKMIDIInputPort.h
+++ b/Source/MIKMIDIInputPort.h
@@ -24,15 +24,12 @@ typedef void(^MIKMIDIEventHandlerBlock)(MIKMIDISourceEndpoint *source, MIKArrayO
  */
 @interface MIKMIDIInputPort : MIKMIDIPort
 
-- (BOOL)connectToSource:(MIKMIDISourceEndpoint *)source error:(NSError **)error;
-- (void)disconnectFromSource:(MIKMIDISourceEndpoint *)source;
+- (id)connectToSource:(MIKMIDISourceEndpoint *)source
+				error:(NSError **)error
+		 eventHandler:(MIKMIDIEventHandlerBlock)eventHandler;
+- (void)disconnectConnectionForToken:(id)token;
 
 @property (nonatomic, strong, readonly) MIKArrayOf(MIKMIDIEndpoint *) *connectedSources;
-
-@property (nonatomic, strong, readonly) NSSet *eventHandlers;
-- (id)addEventHandler:(MIKMIDIEventHandlerBlock)eventHandler; // Returns a token
-- (void)removeEventHandlerForToken:(id)token;
-- (void)removeAllEventHandlers;
 
 @property (nonatomic) BOOL coalesces14BitControlChangeCommands; // Default is YES
 

--- a/Source/MIKMIDIInputPort.m
+++ b/Source/MIKMIDIInputPort.m
@@ -82,7 +82,7 @@
 		![self connectToSource:source error:error]) {
 		return nil;
 	}
-
+	
 	NSString *uuidString = [self createNewConnectionToken];
 	[self addConnectionToken:uuidString andEventHandler:eventHandler forSource:source];
 	return uuidString;
@@ -134,10 +134,12 @@
 	do { // Very unlikely, but just to be safe
 		uuidString = [[NSUUID UUID] UUIDString];
 		MIKMIDIConnectionTokenAndEventHandler *existingPair = nil;
-		for (MIKMIDIConnectionTokenAndEventHandler *pair in self.handlerTokenPairsByEndpoint.objectEnumerator) {
-			if ([pair.connectionToken isEqualToString:uuidString]) {
-				existingPair = pair;
-				break;
+		for (NSArray *handlerPairs in self.handlerTokenPairsByEndpoint.objectEnumerator) {
+			for (MIKMIDIConnectionTokenAndEventHandler *pair in handlerPairs) {
+				if ([pair.connectionToken isEqualToString:uuidString]) {
+					existingPair = pair;
+					break;
+				}
 			}
 		}
 		if (!existingPair) break;

--- a/Source/MIKMIDIInputPort.m
+++ b/Source/MIKMIDIInputPort.m
@@ -194,20 +194,6 @@
 	return controlChange.controllerNumber < 32;
 }
 
-- (BOOL)command:(MIKMIDICommand *)lsbCommand isPossibleLSBOfMSBCommand:(MIKMIDICommand *)msbCommand;
-{
-	if (lsbCommand.commandType != MIKMIDICommandTypeControlChange) return NO;
-	if (msbCommand.commandType != MIKMIDICommandTypeControlChange) return NO;
-	
-	MIKMIDIControlChangeCommand *lsbControlChange = (MIKMIDIControlChangeCommand *)lsbCommand;
-	MIKMIDIControlChangeCommand *msbControlChange = (MIKMIDIControlChangeCommand *)msbCommand;
-	
-	if (msbControlChange.controllerNumber > 31) return NO;
-	if (lsbControlChange.controllerNumber < 32 || lsbControlChange.controllerNumber > 63) return NO;
-	
-	return (lsbControlChange.controllerNumber - msbControlChange.controllerNumber) == 32;
-}
-
 - (NSArray *)commandsByCoalescingCommands:(NSArray *)commands
 {
 	NSMutableArray *coalescedCommands = [commands mutableCopy];

--- a/Source/MIKMIDIMappingGenerator.m
+++ b/Source/MIKMIDIMappingGenerator.m
@@ -566,10 +566,7 @@ FINALIZE_RESULT_AND_RETURN:
 
 - (void)disconnectFromDevice
 {
-	NSArray *sources = [self.device.entities valueForKeyPath:@"@unionOfArrays.sources"];
-	if (![sources count]) return;
-	MIKMIDISourceEndpoint *source = [sources objectAtIndex:0];
-	[[MIKMIDIDeviceManager sharedDeviceManager] disconnectInput:source forConnectionToken:self.connectionToken];
+	[[MIKMIDIDeviceManager sharedDeviceManager] disconnectConnectionforToken:self.connectionToken];
 }
 
 #pragma mark - Properties

--- a/Source/MIKMIDIOutputPort.h
+++ b/Source/MIKMIDIOutputPort.h
@@ -12,7 +12,7 @@
 @class MIKMIDIDestinationEndpoint;
 
 /**
- *  MIKMIDIInputPort is an Objective-C wrapper for CoreMIDI's MIDIPort class, and is only for destination ports.
+ *  MIKMIDIOutputPort is an Objective-C wrapper for CoreMIDI's MIDIPort class, and is only for destination ports.
  *  It is not intended for use by clients/users of of MIKMIDI. Rather, it should be thought of as an
  *  MIKMIDI private class.
  */


### PR DESCRIPTION
This does deprecate one method, `-[MIKMIDIDeviceManager disconnectInput:forConnectionToken]` in favor of the simpler `-disconnectConnectionforToken:`. The deprecated method remains available and functional.