### PR TITLE
Potential zero packet length error

### DIFF
--- a/Source/MIKMIDIClientDestinationEndpoint.m
+++ b/Source/MIKMIDIClientDestinationEndpoint.m
@@ -88,9 +88,10 @@ void MIKMIDIDestinationReadProc(const MIDIPacketList *pktList, void *readProcRef
 		NSMutableArray *receivedCommands = [NSMutableArray array];
 		MIDIPacket *packet = (MIDIPacket *)pktList->packet;
 		for (int i=0; i<pktList->numPackets; i++) {
-			if (packet->length == 0) continue;
-			NSArray *commands = [MIKMIDICommand commandsWithMIDIPacket:packet];
-			if (commands) [receivedCommands addObjectsFromArray:commands];
+            if (packet->length > 0) {
+                NSArray *commands = [MIKMIDICommand commandsWithMIDIPacket:packet];
+                if (commands) [receivedCommands addObjectsFromArray:commands];
+            }
 			packet = MIDIPacketNext(packet);
 		}
 		

--- a/Source/MIKMIDIInputPort.m
+++ b/Source/MIKMIDIInputPort.m
@@ -238,9 +238,10 @@ void MIKMIDIPortReadCallback(const MIDIPacketList *pktList, void *readProcRefCon
 		NSMutableArray *receivedCommands = [NSMutableArray array];
 		MIDIPacket *packet = (MIDIPacket *)pktList->packet;
 		for (int i=0; i<pktList->numPackets; i++) {
-			if (packet->length == 0) continue;
-			NSArray *commands = [MIKMIDICommand commandsWithMIDIPacket:packet];
-			if (commands) [receivedCommands addObjectsFromArray:commands];
+            if (packet->length > 0) {
+                NSArray *commands = [MIKMIDICommand commandsWithMIDIPacket:packet];
+                if (commands) [receivedCommands addObjectsFromArray:commands];
+            }
 			packet = MIDIPacketNext(packet);
 		}
 		


### PR DESCRIPTION
I don’t believe this can happen as core midi seems to follow the
following logic: a packet is only returned when there are at least 3
bytes and the read has timed out.