### PR TITLE
Fixed MIDIObject's hash implementation

### DIFF
--- a/Source/MIKMIDIDevice.m
+++ b/Source/MIKMIDIDevice.m
@@ -80,7 +80,9 @@
 
 - (NSUInteger)hash
 {
-	if (!self.isVirtual) return (NSUInteger)self.uniqueID;
+	if (!self.isVirtual) {
+		return [super hash];
+	}
 	return [self.entities hash];
 }
 

--- a/Source/MIKMIDIObject.m
+++ b/Source/MIKMIDIObject.m
@@ -20,6 +20,9 @@
 static NSMutableSet *registeredMIKMIDIObjectSubclasses;
 
 @interface MIKMIDIObject ()
+{
+	NSUInteger _hash;
+}
 
 @property (nonatomic, readwrite) MIDIObjectRef objectRef;
 @property (nonatomic, readwrite) MIDIUniqueID uniqueID;
@@ -95,7 +98,10 @@ static NSMutableSet *registeredMIKMIDIObjectSubclasses;
 	return self.uniqueID == [(MIKMIDIObject *)object uniqueID];
 }
 
-- (NSUInteger)hash { return self.uniqueID; }
+- (NSUInteger)hash
+{
+	return _hash;
+}
 
 - (NSString *)description
 {
@@ -118,6 +124,8 @@ static NSMutableSet *registeredMIKMIDIObjectSubclasses;
 
 #pragma mark - Properties
 
+@synthesize uniqueID = _uniqueID;
+
 - (MIDIUniqueID)uniqueID
 {
 	if (!_uniqueID) {
@@ -130,6 +138,12 @@ static NSMutableSet *registeredMIKMIDIObjectSubclasses;
 		self.uniqueID = value;
 	}
 	return _uniqueID;
+}
+
+- (void)setUniqueID:(MIDIUniqueID)uniqueID
+{
+	_uniqueID = uniqueID;
+	_hash = @(uniqueID).hash;
 }
 
 - (BOOL)isOnline


### PR DESCRIPTION
`MIDIUniqueID` 's type being SInt32, ie. an int, it is not directly compatible with -hash which is unsigned int. I've seen many unique IDs being negative and when they get cast to UInt, their value ends up being `18446744073709551160` ie. `NSUIntegerMax` which is not at all unique.
Hence, we start to return similar hashes for different MIDI objects.

This simple fix uses NSNumber's native hash implementation.