### PR TITLE
Implemented Sysex Coalescing

### DIFF
--- a/Framework/MIKMIDI Tests/MIKMIDISysexCoalescingTests.m
+++ b/Framework/MIKMIDI Tests/MIKMIDISysexCoalescingTests.m
@@ -113,7 +113,7 @@
 	pktList.packet[0] = testPacket;
 	
 	[_debugInputPort interpretPacketList:&pktList handleResultingCommands:^(NSArray<MIKMIDICommand *> *receivedCommands) {
-		XCTAssert([_validSysexData isEqualToData:receivedCommands.firstObject.data], @"Sysex coalescing should have ended because of an invalid start byte in noteOnPacket");
+		XCTAssert([_validSysexData isEqualToData:receivedCommands.firstObject.data], @"Coalescing of non-terminated sysex message should have ended after time-out");
 		[expectation fulfill];
 	}];
 				  

--- a/Framework/MIKMIDI Tests/MIKMIDISysexCoalescingTests.m
+++ b/Framework/MIKMIDI Tests/MIKMIDISysexCoalescingTests.m
@@ -46,7 +46,7 @@
 	
 	[_debugInputPort coalesceSysexFromMIDIPacket:&testPacket toCommandInArray:&cmdArray];
 	
-	XCTAssert([_validSysexData isEqualToData:cmdArray.firstObject.data]);
+	XCTAssert([_validSysexData isEqualToData:cmdArray.firstObject.data], @"Single-packet sysex message failed coalescing properly");
 }
 		
 - (void)testMultiplePacketsMessage
@@ -59,7 +59,7 @@
 		[_debugInputPort coalesceSysexFromMIDIPacket:&chunk toCommandInArray:&cmdArray];
 	}
 	
-	XCTAssert([_validSysexData isEqualToData:cmdArray.firstObject.data]);
+	XCTAssert([_validSysexData isEqualToData:cmdArray.firstObject.data], @"Chunked sysex message failed coalescing properly");
 }
 
 - (void)testNonTerminatedSysexFollowedByCommand

--- a/Framework/MIKMIDI Tests/MIKMIDISysexCoalescingTests.m
+++ b/Framework/MIKMIDI Tests/MIKMIDISysexCoalescingTests.m
@@ -1,0 +1,83 @@
+//
+//  MIKMIDISysexCoalescingTests.m
+//  MIKMIDI
+//
+//  Created by Benjamin Jaeger on 15.06.2017.
+//  Copyright © 2017 Mixed In Key. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <MIKMIDI/MIKMIDI.h>
+
+@interface MIKMIDIDeviceManager ()
+@property (nonatomic, strong) MIKMIDIInputPort *inputPort;
+@end
+
+@interface MIKMIDIInputPort ()
+- (BOOL)coalesceSysexFromMIDIPacket:(const MIDIPacket *)packet toCommandInArray:(NSMutableArray **)commandsArray;
+@end
+
+@interface MIKMIDISysexCoalescingTests : XCTestCase
+@property (strong) MIKMIDIInputPort *debugInputPort;
+@property (strong) NSData *validSysexData;
+@end
+
+@implementation MIKMIDISysexCoalescingTests
+
+- (void)setUp
+{
+	[super setUp];
+	_debugInputPort = [MIKMIDIDeviceManager sharedDeviceManager].inputPort;
+	_validSysexData = [NSData dataWithBytes:"\xF0\x41\x30\x00\x60\x00\x00\x00\x00\x00\x7f\x00\x00\x00\x00\x7f\x00\x00\x00\x00\x00\x2a\x1d\xF7" length:24];
+}
+
+- (void)tearDown
+{
+	[super tearDown];
+	_debugInputPort = nil;
+	_validSysexData = nil;
+}
+
+- (void)testSinglePacketMessage
+{
+	NSMutableArray <MIKMIDICommand*> *cmdArray = [NSMutableArray new];
+	
+	MIDIPacket testPacket = [self packetWithData:_validSysexData];
+	
+	[_debugInputPort coalesceSysexFromMIDIPacket:&testPacket toCommandInArray:&cmdArray];
+	
+	XCTAssert([_validSysexData isEqualToData:cmdArray.firstObject.data]);
+}
+		
+- (void)testMultiplePacketsMessage
+{
+	NSMutableArray <MIKMIDICommand*> *cmdArray = [NSMutableArray new];
+	
+	// Split into 6 chunks
+	for (NSUInteger i=0; i<6; i++) {
+		MIDIPacket chunk = [self packetWithData:[_validSysexData subdataWithRange:NSMakeRange(i*4, 4)]];
+		[_debugInputPort coalesceSysexFromMIDIPacket:&chunk toCommandInArray:&cmdArray];
+	}
+	
+	XCTAssert([_validSysexData isEqualToData:cmdArray.firstObject.data]);
+}
+		
+#pragma mark - Helpers
+
+- (MIDIPacket)packetWithData:(NSData *)byteArray
+{
+	NSParameterAssert(byteArray.length < 256);
+	
+	MIDIPacket packet = {0};
+	packet.timeStamp = mach_absolute_time();
+	packet.length = byteArray.length;
+	
+	Byte *bytes = (Byte *)byteArray.bytes;
+	for (NSUInteger i=0; i<byteArray.length; i++) {
+		packet.data[i] = bytes[i];
+	}
+	
+	return packet;
+}
+
+@end

--- a/Framework/MIKMIDI.xcodeproj/project.pbxproj
+++ b/Framework/MIKMIDI.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6609EF0C1EF300C400B4DAE5 /* MIKMIDISysexCoalescingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6609EF0B1EF300C400B4DAE5 /* MIKMIDISysexCoalescingTests.m */; };
 		8308F6321B46C482004307AD /* MIKMIDICommandScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8308F6311B46C482004307AD /* MIKMIDICommandScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		833B73DA1A262FE100E0CC9F /* MIKMIDISequencer.h in Headers */ = {isa = PBXBuildFile; fileRef = 833B73D81A262FE100E0CC9F /* MIKMIDISequencer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		833B73DB1A262FE100E0CC9F /* MIKMIDISequencer.m in Sources */ = {isa = PBXBuildFile; fileRef = 833B73D91A262FE100E0CC9F /* MIKMIDISequencer.m */; };
@@ -315,6 +316,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6609EF0B1EF300C400B4DAE5 /* MIKMIDISysexCoalescingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MIKMIDISysexCoalescingTests.m; sourceTree = "<group>"; };
 		8308F6311B46C482004307AD /* MIKMIDICommandScheduler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MIKMIDICommandScheduler.h; sourceTree = "<group>"; };
 		833B73D81A262FE100E0CC9F /* MIKMIDISequencer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MIKMIDISequencer.h; sourceTree = "<group>"; };
 		833B73D91A262FE100E0CC9F /* MIKMIDISequencer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MIKMIDISequencer.m; sourceTree = "<group>"; };
@@ -537,6 +539,7 @@
 			isa = PBXGroup;
 			children = (
 				9D4DF13E1AAB57430065F004 /* MIKMIDI_Tests.m */,
+				6609EF0B1EF300C400B4DAE5 /* MIKMIDISysexCoalescingTests.m */,
 				9D1D9C241BF542BB001377F7 /* MIKMIDICommandTests.m */,
 				9D4DF14C1AAB57800065F004 /* MIKMIDISequenceTests.m */,
 				9D4DF1531AAB60490065F004 /* MIKMIDITrackTests.m */,
@@ -1169,6 +1172,7 @@
 				9D1D9C251BF542BB001377F7 /* MIKMIDICommandTests.m in Sources */,
 				9DCDDB5A1AB3514100F8347E /* MIKMIDISequencerTests.m in Sources */,
 				9D0225311CC92ECF0090EAB4 /* MIKMIDIMetaEventTests.m in Sources */,
+				6609EF0C1EF300C400B4DAE5 /* MIKMIDISysexCoalescingTests.m in Sources */,
 				9D4DF13F1AAB57430065F004 /* MIKMIDI_Tests.m in Sources */,
 				9D2ED25F1AFBD062000325CC /* MIKMIDIResponderChainTests.m in Sources */,
 				9D4DF14D1AAB57800065F004 /* MIKMIDISequenceTests.m in Sources */,

--- a/Source/MIKMIDIInputPort.h
+++ b/Source/MIKMIDIInputPort.h
@@ -31,7 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL coalesces14BitControlChangeCommands; // Default is YES
 
-
 /**
  * Time before sysex transmissions are considered over.
  *

--- a/Source/MIKMIDIInputPort.h
+++ b/Source/MIKMIDIInputPort.h
@@ -31,6 +31,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL coalesces14BitControlChangeCommands; // Default is YES
 
+
+/**
+ * Time before sysex transmissions are considered over.
+ *
+ * This takes care of interruption in the data (devices being turned off or unplugged) as well as
+ * ill-behaved devices which don't terminate their sysex messages with 0xF7.
+ */
+@property (assign) NSTimeInterval sysexTimeOut;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/MIKMIDIInputPort.m
+++ b/Source/MIKMIDIInputPort.m
@@ -271,7 +271,7 @@ void MIKMIDIPortReadCallback(const MIDIPacketList *pktList, void *readProcRefCon
 				// this is nonoptimal and needs better safeguards, but should work in most cases.
 				
 				// sysexData being atomic, we can safely add to it without locking
-				[self.sysexData appendBytes:packet->data length:packet->length];
+				[self.sysexData appendBytes:data length:length];
 				
 				// Check for Sysex End
 				if(data[length - 1] == kMIKMIDISysexEndDelimiter) {

--- a/Source/MIKMIDIInputPort.m
+++ b/Source/MIKMIDIInputPort.m
@@ -247,11 +247,9 @@
 		
 		self.sysexData = nil;
 		self.sysexStartTimeStamp = 0;
-		
-		return YES;
 	}
 	
-	return NO;
+	return YES;
 }
 
 #pragma mark Command Handling

--- a/Source/MIKMIDIInputPort.m
+++ b/Source/MIKMIDIInputPort.m
@@ -223,10 +223,7 @@
 }
 
 - (BOOL)coalesceSysexInMIDIPacket:(const MIDIPacket *)packet intoCommandsArray:(NSMutableArray **)commandsArray
-{
-	// Warning: This code assumes sysex chunks end at packet end and have a valid EOT marker (0xF7)
-	// this is nonoptimal and needs better safeguards, but should work in most cases.
-	
+{	
 	const Byte *data = packet->data;
 	UInt16 originalLength = packet->length;
 	

--- a/Source/MIKMIDIInputPort.m
+++ b/Source/MIKMIDIInputPort.m
@@ -227,18 +227,17 @@
 	const Byte *data = packet->data;
 	UInt16 length = packet->length;
 	
-	if(self.sysexData != nil) {
-		[self.sysexData appendBytes:data length:length];
-	}
-	else {
+	if(self.sysexData == nil) {
 		// Check for Sysex Begin
-		if(data[0] == kMIKMIDISysexBeginDelimiter) {
-			self.sysexData = [NSMutableData dataWithBytes:data length:length];
-			self.sysexStartTimeStamp = packet->timeStamp;
-		}
-		else {
+		if(data[0] != kMIKMIDISysexBeginDelimiter) {
 			return NO;
 		}
+		
+		self.sysexData = [NSMutableData dataWithBytes:data length:length];
+		self.sysexStartTimeStamp = packet->timeStamp;
+	}
+	else {
+		[self.sysexData appendBytes:data length:length];
 	}
 	
 	// Check for Sysex End

--- a/Source/MIKMIDIInputPort.m
+++ b/Source/MIKMIDIInputPort.m
@@ -394,7 +394,7 @@ void MIKMIDIPortReadCallback(const MIDIPacketList *pktList, void *readProcRefCon
 		return;
 	}
 	
-	completionBlock(@[receivedCommands]);
+	completionBlock(receivedCommands);
 }
 
 #pragma mark - Properties

--- a/Source/MIKMIDIInputPort.m
+++ b/Source/MIKMIDIInputPort.m
@@ -347,6 +347,7 @@ void MIKMIDIPortReadCallback(const MIDIPacketList *pktList, void *readProcRefCon
 			packet = MIDIPacketNext(packet);
 		}
 		
+		// Safeguard against sysex time-out
 		if(self.isCoalescingSysex) {
 			// Create or extend time-out timer
 			if(!self.sysexTimeOutTimer) {
@@ -363,13 +364,13 @@ void MIKMIDIPortReadCallback(const MIDIPacketList *pktList, void *readProcRefCon
 			}
 			return;
 		}
-		else {
-			// Clear Sysex Timer
-			[self.sysexTimeOutTimer invalidate];
-			self.sysexTimeOutTimer = nil;
-		}
 		
-		if ([receivedCommands count] == 0) {
+		// Clear Sysex Timer
+		[self.sysexTimeOutTimer invalidate];
+		self.sysexTimeOutTimer = nil;
+		
+		// Handle Commands
+		if(receivedCommands.count == 0) {
 			return;
 		}
 		

--- a/Source/MIKMIDIInputPort.m
+++ b/Source/MIKMIDIInputPort.m
@@ -351,6 +351,12 @@ void MIKMIDIPortReadCallback(const MIDIPacketList *pktList, void *readProcRefCon
 			// Create or extend time-out timer
 			if(!self.sysexTimeOutTimer) {
 				self.sysexTimeOutTimer = [NSTimer timerWithTimeInterval:self.sysexTimeOut target:self selector:@selector(sysexCoalescingTimedOut:) userInfo:@{@"MIKMIDISourceEndpoint":source} repeats:NO];
+				
+				// Run Timer
+				NSRunLoop *currentRunLoop = [NSRunLoop currentRunLoop];
+				NSRunLoopMode mode = currentRunLoop.currentMode ?: NSDefaultRunLoopMode;
+				
+				[currentRunLoop addTimer:self.sysexTimeOutTimer forMode:mode];
 			}
 			else {
 				self.sysexTimeOutTimer.fireDate = [NSDate dateWithTimeIntervalSinceNow:self.sysexTimeOut];

--- a/Source/MIKMIDISystemExclusiveCommand.h
+++ b/Source/MIKMIDISystemExclusiveCommand.h
@@ -13,6 +13,7 @@
 #define kMIKMIDISysexRealtimeManufacturerID 0x7F
 
 #define kMIKMIDISysexChannelDisregard 0x7F
+#define kMIKMIDISysexBeginDelimiter 0xF0
 #define kMIKMIDISysexEndDelimiter 0xF7
 
 NS_ASSUME_NONNULL_BEGIN
@@ -36,6 +37,14 @@ NS_ASSUME_NONNULL_BEGIN
  *  @return An identity request command object.
  */
 + (instancetype)identityRequestCommand;
+
+/**
+ * Initializes the command with raw sysex data and timestamp.
+ *
+ * @param data Assumed to be valid with begin+end delimiters.
+ * @param timeStamp Time at which the first sysex byte was received.
+ */
+- (id)initWithRawData:(NSData *)data timeStamp:(MIDITimeStamp)timeStamp;
 
 /**
  *  The manufacturer ID for the command. This is used by devices to determine

--- a/Source/MIKMIDISystemExclusiveCommand.m
+++ b/Source/MIKMIDISystemExclusiveCommand.m
@@ -75,6 +75,16 @@
     return self;
 }
 
+- (id)initWithRawData:(NSData *)data timeStamp:(MIDITimeStamp)timeStamp
+{
+	self = [super initWithMIDIPacket:NULL];
+	if (self) {
+		self.midiTimestamp = timeStamp;
+		self.internalData = data.mutableCopy;
+	}
+	return self;
+}
+
 - (UInt32)manufacturerID
 {
     if ([self.internalData length] < 2) return 0;


### PR DESCRIPTION
References Issues #198, #122
Alternative Implementation to PR #130

Safeguards:
- [x] Handle invalid start byte in each packet's data (NOT IN [0 - 0x7F])
- [x] Handle EOT regardless of byte position in stream. Ignore remaining data in packet.
- [x] Handle absence of EOT, or timed-out transmissions: End Sysex when a timer expires.

_EOT = End of transmission marker 0xF7_

Took some hints from [SnoizeMIDI](https://github.com/krevis/MIDIApps/blob/223f363451e5c7f457420788f2b3652899b3f472/Frameworks/SnoizeMIDI/SMMessageParser.m#L218) Source