### PR TITLE
Fixed Reading MIDIPacket with Multiple Messages

### DIFF
--- a/Source/MIKMIDICommand.m
+++ b/Source/MIKMIDICommand.m
@@ -57,7 +57,7 @@ static NSMutableSet *registeredMIKMIDICommandSubclasses;
 		const Byte *packetData = inputPacket->data + dataOffset;
 		NSInteger commandType = (NSInteger) packetData[0];
 		NSInteger standardLength = MIKMIDIStandardLengthOfMessageForCommandType(commandType);
-        if (dataOffset > (inputPacket->length - standardLength)) break;
+		if (dataOffset > (inputPacket->length - standardLength)) break;
 
 		// This is gross, but it's the only way I can find to reliably create a
 		// single-message MIDIPacket.

--- a/Source/MIKMIDICommand.m
+++ b/Source/MIKMIDICommand.m
@@ -51,28 +51,14 @@ static NSMutableSet *registeredMIKMIDICommandSubclasses;
 
 + (NSArray *)commandsWithMIDIPacket:(MIDIPacket *)inputPacket
 {
-	NSInteger firstCommandType = inputPacket->data[0];
-	NSInteger standardLength = MIKMIDIStandardLengthOfMessageForCommandType(firstCommandType);
-	if (standardLength <= 0 || inputPacket->length == standardLength) {
-		// Can't parse multiple message because we don't know the length of each one,
-		// or there's only one message there
-		MIKMIDICommand *command = [MIKMIDICommand commandWithMIDIPacket:inputPacket];
-		return command ? @[command] : @[];
-	}
-	
 	NSMutableArray *result = [NSMutableArray array];
-	NSInteger packetCount = 0;
+	NSInteger dataOffset = 0;
 	while (1) {
-		
-		NSInteger dataOffset = packetCount * standardLength;
-		if (dataOffset > (inputPacket->length - standardLength)) break;
 		const Byte *packetData = inputPacket->data + dataOffset;
-		if (packetData[0] != firstCommandType && ((packetData[0] | 0x0F) != (firstCommandType | 0x0F))) {
-			// Doesn't look like multiple messages because they're not all the same type
-			MIKMIDICommand *command = [MIKMIDICommand commandWithMIDIPacket:inputPacket];
-			return command ? @[command] : @[];
-		}
-		
+		NSInteger commandType = (NSInteger) packetData[0];
+		NSInteger standardLength = MIKMIDIStandardLengthOfMessageForCommandType(commandType);
+        if (dataOffset > (inputPacket->length - standardLength)) break;
+
 		// This is gross, but it's the only way I can find to reliably create a
 		// single-message MIDIPacket.
 		MIDIPacketList packetList;
@@ -85,9 +71,9 @@ static NSMutableSet *registeredMIKMIDICommandSubclasses;
 										  packetData);
 		MIKMIDICommand *command = [MIKMIDICommand commandWithMIDIPacket:midiPacket];
 		if (command) [result addObject:command];
-		packetCount++;
+		dataOffset += standardLength;
 	}
-	
+
 	return result;
 }
 


### PR DESCRIPTION
## Description

Fix regarding this issue: https://github.com/mixedinkey-opensource/MIKMIDI/issues/201

Some MIDI keyboards send more than one command of _different_ types in a single MIDI packet (e.g. control change followed by "Note On"). The code now supports that.

## Changes 

- `commandsWithMIDIPacket` in `MIKMIDICommand.m`: instead of looking at just the first command type/length, it iterates through each one and advances the offset by the command's length.


