### PR TITLE
Fix duplicated code in MIKMIDIConnectionManager, fix crash when passing NULL to -commandWithMIDIPacket:

### DIFF
--- a/Source/MIKMIDICommand.m
+++ b/Source/MIKMIDICommand.m
@@ -41,9 +41,13 @@ static NSMutableSet *registeredMIKMIDICommandSubclasses;
 
 + (instancetype)commandWithMIDIPacket:(MIDIPacket *)packet;
 {
-	MIKMIDICommandType commandType = packet->data[0];
-	
-	Class subclass = [[self class] subclassForCommandType:commandType];
+    Class subclass;
+    // initWithMIDIPacket get be passed a NULL packet, so we should accept a NULL packet here, too
+    if(packet) {
+        MIKMIDICommandType commandType = packet->data[0];
+        subclass = [[self class] subclassForCommandType:commandType];
+    }
+    
 	if (!subclass) subclass = self;
 	if ([self isMutable]) subclass = [subclass mutableCounterpartClass];
 	return [[subclass alloc] initWithMIDIPacket:packet];
@@ -69,6 +73,7 @@ static NSMutableSet *registeredMIKMIDICommandSubclasses;
 										  inputPacket->timeStamp,
 										  standardLength,
 										  packetData);
+        
 		MIKMIDICommand *command = [MIKMIDICommand commandWithMIDIPacket:midiPacket];
 		if (command) [result addObject:command];
 		dataOffset += standardLength;

--- a/Source/MIKMIDICommand.m
+++ b/Source/MIKMIDICommand.m
@@ -42,7 +42,6 @@ static NSMutableSet *registeredMIKMIDICommandSubclasses;
 + (instancetype)commandWithMIDIPacket:(MIDIPacket *)packet;
 {
     Class subclass;
-    // initWithMIDIPacket get be passed a NULL packet, so we should accept a NULL packet here, too
     if(packet) {
         MIKMIDICommandType commandType = packet->data[0];
         subclass = [[self class] subclassForCommandType:commandType];

--- a/Source/MIKMIDIConnectionManager.m
+++ b/Source/MIKMIDIConnectionManager.m
@@ -230,10 +230,6 @@ BOOL MIKMIDINoteOffCommandCorrespondsWithNoteOnCommand(MIKMIDINoteOffCommand *no
 			MIKMIDIDevice *device = [MIKMIDIDevice deviceWithVirtualEndpoints:@[endpoint]];
 			if (device) [result addObject:device];
 		}
-		for (MIKMIDIEndpoint *endpoint in devicelessSources) {
-			MIKMIDIDevice *device = [MIKMIDIDevice deviceWithVirtualEndpoints:@[endpoint]];
-			if (device) [result addObject:device];
-		}
 	}
 	
 	self.availableDevices = [result copy];


### PR DESCRIPTION
1) Deleted duplicated code that was causing two devices to show up in connection manager list
2) Changed the [MIKMIDICommand commandWithMIDIPacket] initializer so that it doesn't crash when passed a NULL packet.