### PR TITLE
Add restart MIDI functions

### DIFF
--- a/Source/MIKMIDIDeviceManager.h
+++ b/Source/MIKMIDIDeviceManager.h
@@ -74,6 +74,14 @@ extern NSString * const MIKMIDIEndpointKey;
  */
 + (instancetype)sharedDeviceManager;
 
+/*
+ * Use to restart MIDI after the application connected to MIDI device via bluetooth
+ * Need this method because. If not restart then: after connect to midi successful via bluetooth the function
+ * `void MIKMIDIDeviceManagerNotifyCallback(const MIDINotification *message, void *refCon)` didn't called
+ * we also need sleep some second before call restart MIDI to make affected
+ */
+- (void)restartMidiClient;
+
 /**
  *  Used to connect to a MIDI device. Returns a token that must be kept and passed into the
  *  -disconnectConnectionforToken: method.

--- a/Source/MIKMIDIDeviceManager.h
+++ b/Source/MIKMIDIDeviceManager.h
@@ -75,6 +75,7 @@ extern NSString * const MIKMIDIEndpointKey;
 + (instancetype)sharedDeviceManager;
 
 /*
+ * Call this method after your app connect to MIDI device via bluetooth successful.
  * Use to restart MIDI after the application connected to MIDI device via bluetooth
  * Need this method because. If not restart then: after connect to midi successful via bluetooth the function
  * `void MIKMIDIDeviceManagerNotifyCallback(const MIDINotification *message, void *refCon)` didn't called

--- a/Source/MIKMIDIDeviceManager.m
+++ b/Source/MIKMIDIDeviceManager.m
@@ -102,6 +102,11 @@ static MIKMIDIDeviceManager *sharedDeviceManager;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+-(void)restartMidiClient {
+    sleep(3);//IS this time enough for restart the Midi? I dont know, just work around for this number.
+    MIDIRestart();
+}
+
 #pragma mark - Public
 
 - (nullable id)connectDevice:(MIKMIDIDevice *)device error:(NSError **)error eventHandler:(MIKMIDIEventHandlerBlock)eventHandler

--- a/Source/MIKMIDIDeviceManager.m
+++ b/Source/MIKMIDIDeviceManager.m
@@ -103,7 +103,8 @@ static MIKMIDIDeviceManager *sharedDeviceManager;
 }
 
 -(void)restartMidiClient {
-    sleep(3);//IS this time enough for restart the Midi? I dont know, just work around for this number.
+    //This time is need for watting after MIDI devices connected, to make restart effected.
+    sleep(3);
     MIDIRestart();
 }
 


### PR DESCRIPTION
With BLE Midi devices, we cannot search and connect into `Setting` of iOS devices. The problem is the application which call `sharedDeviceManager` at `AppDelegate` will cannot receive notification for new income MIDI devices which connected via bluetooth(into setting page of the app). The good way to resolve the problem is add method for restart midi. we also need sleep about 3 seconds before call restart to make it affected.