### PR TITLE
Implement support for loading/saving mappings in iOS (Issue 131)

### DIFF
--- a/Source/MIKMIDIMappingManager.h
+++ b/Source/MIKMIDIMappingManager.h
@@ -77,7 +77,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (MIKArrayOf(MIKMIDIMapping *) *)mappingsWithName:(NSString *)mappingName;
 
-#if !TARGET_OS_IPHONE
 /**
  *  Import and load a user-supplied MIDI mapping XML file. This method loads the MIDI mapping
  *  file specified by URL and adds it to the set returned by -userMappings. The newly imported mapping
@@ -87,8 +86,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  If shouldOverwrite is YES, and an existing file with the same URL as would be used
  *  to save the imported mapping already exists, the existing file is deleted. Otherwise,
  *  a unique name is used for the newly imported mapping, preserving both mapping files.
- * 
- *  @note This method is currently only available on OS X. See https://github.com/mixedinkey-opensource/MIKMIDI/issues/2
  *
  *  @param URL             The fileURL for the mapping file to be imported. Should not be nil.
  *  @param shouldOverwrite YES if an existing mapping with the same file name should be overwitten, NO to use a unique file name for the newly imported mapping.
@@ -104,11 +101,8 @@ NS_ASSUME_NONNULL_BEGIN
  * 
  *  This method can be called manually to initiate a save, but is also called automatically anytime a new user mapping is added (via
  *  -importMappingFromFileAtURL:overwritingExistingMapping:error: or -addUserMappingsObject:) as well as upon application termination.
- *
- *  @note This method is currently only available on OS X. See https://github.com/mixedinkey-opensource/MIKMIDI/issues/2 
  */
 - (void)saveMappingsToDisk;
-#endif
 
 // Properties
 

--- a/Source/MIKMIDIMappingManager.m
+++ b/Source/MIKMIDIMappingManager.m
@@ -146,7 +146,6 @@ static MIKMIDIMappingManager *sharedManager = nil;
 
 - (MIKMIDIMapping *)importMappingFromFileAtURL:(NSURL *)URL overwritingExistingMapping:(BOOL)shouldOverwrite error:(NSError **)error;
 {
-#if !TARGET_OS_IPHONE
 	error = error ? error : &(NSError *__autoreleasing){ nil };
 	if (![[URL pathExtension] isEqualToString:kMIKMIDIMappingFileExtension]) {
 		NSString *recoverySuggestion = [NSString stringWithFormat:NSLocalizedString(@"%1$@ can't be imported, because it does not have the file extension %2$@.", @"MIDI mapping import failed because of incorrect file extension message. Placeholder 1 is the filename, 2 is the required extension (e.g. 'midimap')")];
@@ -169,13 +168,10 @@ static MIKMIDIMappingManager *sharedManager = nil;
 	
 	[self addUserMappingsObject:mapping];
 	return mapping;
-#endif // TARGET_OS_IPHONE
-	return nil;
 }
 
 - (void)saveMappingsToDisk
 {
-#if !TARGET_OS_IPHONE
 	for (MIKMIDIMapping *mapping in self.userMappings) {
 		NSURL *fileURL = [self fileURLForMapping:mapping shouldBeUnique:NO];
 		if (!fileURL) {
@@ -185,7 +181,6 @@ static MIKMIDIMappingManager *sharedManager = nil;
 		
 		[mapping writeToFileAtURL:fileURL error:NULL];
 	}
-#endif
 }
 
 #pragma mark - Private

--- a/Source/MIKMIDIMappingXMLParser.m
+++ b/Source/MIKMIDIMappingXMLParser.m
@@ -128,7 +128,12 @@
 		[self.currentItemInfo removeObjectForKey:@"commandIdentifier"];
 		MIKMIDIMappingItem *item = [[MIKMIDIMappingItem alloc] initWithMIDIResponderIdentifier:responderID andCommandIdentifier:commandID];
 		
-		[item setValuesForKeysWithDictionary:self.currentItemInfo];
+		item.additionalAttributes = self.currentItemInfo[@"additionalAttributes"];
+		item.channel = [self.currentItemInfo[@"channel"] integerValue];
+		item.commandType = [self.currentItemInfo[@"commandType"] integerValue];
+		item.controlNumber = [self.currentItemInfo[@"controlNumber"] unsignedIntegerValue];
+		item.flipped = [self.currentItemInfo[@"flipped"] boolValue];
+		item.interactionType = [self.currentItemInfo[@"interactionType"] integerValue];
 		
 		[self.currentMapping addMappingItemsObject:item];
 		
@@ -138,7 +143,11 @@
 	}
 	
 	if ([elementName isEqualToString:self.currentElementName]) {
-		self.currentItemInfo[[elementName mik_uncapitalizedString]] = [self.currentElementValueBuffer copy];
+		// Current element is stored as a string which may need to be converted to an NSNumber
+		NSString* currentElement = [self.currentElementValueBuffer copy];
+		NSScanner* scanner = [NSScanner scannerWithString:currentElement];
+		self.currentItemInfo[[elementName mik_uncapitalizedString]] = ([scanner scanInt:nil] && [scanner isAtEnd]) ? @(currentElement.integerValue) : currentElement;
+		
 		self.currentElementName = nil;
 		self.currentElementValueBuffer = nil;
 		

--- a/Source/MIKMIDIMappingXMLParser.m
+++ b/Source/MIKMIDIMappingXMLParser.m
@@ -143,7 +143,8 @@
 	}
 	
 	if ([elementName isEqualToString:self.currentElementName]) {
-		// Current element is stored as a string which may need to be converted to an NSNumber
+		// Current element is stored as a string which may need to be converted to an NSNumber.
+		// Using NSScanner here, as detailed in https://stackoverflow.com/a/572312/8653957
 		NSString* currentElement = [self.currentElementValueBuffer copy];
 		NSScanner* scanner = [NSScanner scannerWithString:currentElement];
 		self.currentItemInfo[[elementName mik_uncapitalizedString]] = ([scanner scanInt:nil] && [scanner isAtEnd]) ? @(currentElement.integerValue) : currentElement;


### PR DESCRIPTION
For iOS, implemented loading of bundled mappings, and loading/saving of user mappings. Original issue at https://github.com/mixedinkey-opensource/MIKMIDI/issues/131.

This also fixes a crash that occurs when accessing `MIKMIDIMappingManager.shared()` when there is a `.midimap` file present in the bundle (aka: a bundled mapping).