### PR TITLE
Making Device Manager's outputPort method public

### DIFF
--- a/Source/MIKMIDIDeviceManager.h
+++ b/Source/MIKMIDIDeviceManager.h
@@ -140,14 +140,12 @@ extern NSString * const MIKMIDIEndpointKey;
 
 
 /**
- *  Returns the current MIDI output port.
+ *  The current MIDI output port.
  *  Typically this should only be required for custom Core MIDI implementations in C/C++ where MIKMIDI has already been implemented to handle endpoint setup.
  *  Creates a new MIDI output port if one does not already exist.
- *
- *  @return An MIKMIDIOutputPort representing the current MIDI output port.
  */
-- (MIKMIDIOutputPort *)outputPort;
-
+//- (MIKMIDIOutputPort *)outputPort;
+@property (nonatomic, readonly) MIKMIDIOutputPort *outputPort;
 
 
 /**

--- a/Source/MIKMIDIDeviceManager.h
+++ b/Source/MIKMIDIDeviceManager.h
@@ -15,6 +15,7 @@
 @class MIKMIDIClientSourceEndpoint;
 @class MIKMIDIDestinationEndpoint;
 @class MIKMIDICommand;
+@class MIKMIDIOutputPort;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -136,6 +137,16 @@ extern NSString * const MIKMIDIEndpointKey;
  *  @return YES if the commands were successfully sent, NO if an error occurred.
  */
 - (BOOL)sendCommands:(MIKArrayOf(MIKMIDICommand *) *)commands toVirtualEndpoint:(MIKMIDIClientSourceEndpoint *)endpoint error:(NSError **)error;
+
+
+/**
+ *  Returns the current MIDI output port.
+ *  Typically this should only be required for custom Core MIDI implementations in C/C++ where MIKMIDI has already been implemented to handle endpoint setup.
+ *  Creates a new MIDI output port if one does not already exist.
+ *
+ *  @return An MIKMIDIOutputPort representing the current MIDI output port.
+ */
+- (MIKMIDIOutputPort *)outputPort;
 
 
 

--- a/Source/MIKMIDIDeviceManager.h
+++ b/Source/MIKMIDIDeviceManager.h
@@ -144,7 +144,6 @@ extern NSString * const MIKMIDIEndpointKey;
  *  Typically this should only be required for custom Core MIDI implementations in C/C++ where MIKMIDI has already been implemented to handle endpoint setup.
  *  Creates a new MIDI output port if one does not already exist.
  */
-//- (MIKMIDIOutputPort *)outputPort;
 @property (nonatomic, readonly) MIKMIDIOutputPort *outputPort;
 
 


### PR DESCRIPTION
Added an accessor for `outputPort` to MIKMIDIDeviceManager.h, to allow MIKMIDI to be used more efficiently with C/C++ Core MIDI implementations.