### PR TITLE
Issue #304: Add includesThreeByteManufacturerID to MIKMIDISystemExclusiveCommand

### DIFF
--- a/Framework/MIKMIDI Tests/MIKMIDISystemExclusiveCommandTests.m
+++ b/Framework/MIKMIDI Tests/MIKMIDISystemExclusiveCommandTests.m
@@ -78,4 +78,54 @@
 	XCTAssertEqual(command.manufacturerID, 0x002076, @"Setting a 3-byte manufacturerID on a MIKMutableMIDISystemExclusiveCommand instance failed.");
 }
 
+- (void)testChangingManufacturerIDLength
+{
+    MIKMutableMIDISystemExclusiveCommand *command = [[MIKMutableMIDISystemExclusiveCommand alloc] init];
+    command.manufacturerID = 0x41; // Roland
+    XCTAssertFalse(command.includesThreeByteManufacturerID);
+    XCTAssertEqual(command.data.length, 4); // Status, 1-byte manufacturer, (zero) channel, end delimiter byte
+
+    command.manufacturerID = 0x414243;
+    XCTAssertTrue(command.includesThreeByteManufacturerID);
+    XCTAssertEqual(command.manufacturerID, 0x414243, @"Changing the manufacturerID length on a MIKMutableMIDISystemExclusiveCommand instance failed.");
+    XCTAssertEqual(command.data.length, 6); // Status, 3-byte manufacturer, (zero) channel, end delimiter byte
+
+    command.manufacturerID = 0x41;
+    XCTAssertFalse(command.includesThreeByteManufacturerID);
+    XCTAssertEqual(command.manufacturerID, 0x41, @"Changing the manufacturerID length on a MIKMutableMIDISystemExclusiveCommand instance failed.");
+    XCTAssertEqual(command.data.length, 4); // Status, 1-byte manufacturer, (zero) channel, end delimiter byte
+}
+
+- (void)testForcedThreeByteManufacturerIDLength
+{
+    MIKMutableMIDISystemExclusiveCommand *command = [[MIKMutableMIDISystemExclusiveCommand alloc] init];
+    command.manufacturerID = 0x41; // Roland
+    XCTAssertFalse(command.includesThreeByteManufacturerID);
+    XCTAssertEqual(command.data.length, 4); // Status, 1-byte manufacturer, (zero) channel, end delimiter byte
+
+    command.includesThreeByteManufacturerID = YES;
+    XCTAssertEqual(command.manufacturerID, 0x41, @"manufacturerID is wrong after includesThreeByteManufacturerID change");
+    XCTAssertTrue(command.includesThreeByteManufacturerID);
+    XCTAssertEqual(command.data.length, 6); // Status, 3-byte manufacturer, (zero) channel, end delimiter byte
+
+    command.includesThreeByteManufacturerID = NO;
+    XCTAssertEqual(command.manufacturerID, 0x41, @"manufacturerID is wrong after includesThreeByteManufacturerID change");
+    XCTAssertFalse(command.includesThreeByteManufacturerID);
+    XCTAssertEqual(command.data.length, 4); // Status, 1-byte manufacturer, (zero) channel, end delimiter byte
+}
+
+- (void)testSettingIncludesThreeByteManufacturerIDWithThreeByteManufacturerID
+{
+    MIKMutableMIDISystemExclusiveCommand *command = [[MIKMutableMIDISystemExclusiveCommand alloc] init];
+    command.manufacturerID = 0x414243;
+    XCTAssertTrue(command.includesThreeByteManufacturerID);
+    XCTAssertEqual(command.manufacturerID, 0x414243, @"Changing the manufacturerID length on a MIKMutableMIDISystemExclusiveCommand instance failed.");
+    XCTAssertEqual(command.data.length, 6); // Status, 3-byte manufacturer, (zero) channel, end delimiter byte
+
+    command.includesThreeByteManufacturerID = NO;
+    XCTAssertTrue(command.includesThreeByteManufacturerID);
+    XCTAssertEqual(command.manufacturerID, 0x414243, @"manufacturerID is wrong after includesThreeByteManufacturerID change");
+    XCTAssertEqual(command.data.length, 6); // Status, 3-byte manufacturer, (zero) channel, end delimiter byte
+}
+
 @end

--- a/Source/MIKMIDISystemExclusiveCommand.h
+++ b/Source/MIKMIDISystemExclusiveCommand.h
@@ -63,6 +63,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) UInt32 manufacturerID;
 
 /**
+ *  Whether or not the command's data will include three bytes for the manufacturer ID.
+ *  If the first three bytes of the manufacturer ID are non-zero, this *always* returns YES.
+ *  By default, if only the last byte of the manufacturer ID is non-zero, this returns NO.
+ *  It can be set to YES (in MIKMutableMIDISystemExclusiveCommand) to explicitly
+ *  Include all three bytes, including the two leading zero bytes.
+ */
+@property (nonatomic, readonly) BOOL includesThreeByteManufacturerID;
+
+/**
  *  The channel of the message. Only valid for universal exclusive messages,
  *  will always be 0 for non-universal messages.
  */
@@ -90,6 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MIKMutableMIDISystemExclusiveCommand : MIKMIDISystemExclusiveCommand
 
 @property (nonatomic, readwrite) UInt32 manufacturerID;
+@property (nonatomic, readwrite) BOOL includesThreeByteManufacturerID;
 @property (nonatomic, readwrite) UInt8 sysexChannel;
 @property (nonatomic, strong, readwrite) NSData *sysexData;
 

--- a/Source/MIKMIDISystemExclusiveCommand.m
+++ b/Source/MIKMIDISystemExclusiveCommand.m
@@ -32,6 +32,8 @@ uint8_t const kMIKMIDISysexEndDelimiter = 0xF7;
 @implementation MIKMIDISystemExclusiveCommand
 {
 	BOOL _has3ByteManufacturerID;
+    BOOL _includesThreeByteManufacturerID;
+    BOOL _threeByteManufacturerIDInInternalData;
 }
 
 + (void)load { [super load]; [MIKMIDICommand registerSubclass:self]; }
@@ -101,7 +103,7 @@ uint8_t const kMIKMIDISysexEndDelimiter = 0xF7;
 {
 	if ([self.internalData length] < 2) return 0;
 	
-	NSUInteger manufacturerIDLength = _has3ByteManufacturerID ? 3 : 1;
+	NSUInteger manufacturerIDLength = _threeByteManufacturerIDInInternalData ? 3 : 1;
 	NSData *idData = [self.internalData subdataWithRange:NSMakeRange(1, manufacturerIDLength)];
 	UInt8 *bytes = (UInt8 *)[idData bytes];
 	if (manufacturerIDLength == 1) { return bytes[0]; }
@@ -112,16 +114,27 @@ uint8_t const kMIKMIDISysexEndDelimiter = 0xF7;
 {
 	if (![[self class] isMutable]) return MIKMIDI_RAISE_MUTATION_ATTEMPT_EXCEPTION;
 	
-	NSUInteger numExistingBytes = _has3ByteManufacturerID ? 3 : 1;
+	NSUInteger numExistingBytes = _threeByteManufacturerIDInInternalData ? 3 : 1;
 	NSUInteger numNewBytes = (manufacturerID & 0xFFFF00) != 0 ? 3 : 1;
+    _has3ByteManufacturerID = (numNewBytes == 3);
+    if (self.includesThreeByteManufacturerID) { numNewBytes = 3; }
 	manufacturerID = CFSwapInt32HostToBig(manufacturerID);
-	NSUInteger numRequiredBytes = MAX(numExistingBytes, numNewBytes) + 1;
-	if ([self.internalData length] < numRequiredBytes) [self.internalData increaseLengthBy:numRequiredBytes-[self.internalData length]];
-	
 	UInt8 *replacementBytes = (UInt8 *)(&manufacturerID) + 4 - numNewBytes;
 	[self.internalData replaceBytesInRange:NSMakeRange(1, numExistingBytes) withBytes:replacementBytes length:numNewBytes];
-	
-	_has3ByteManufacturerID = (numNewBytes == 3);
+    _threeByteManufacturerIDInInternalData = numNewBytes == 3;
+}
+
+- (BOOL)includesThreeByteManufacturerID
+{
+    if (_has3ByteManufacturerID) { return YES; }
+    return _includesThreeByteManufacturerID;
+}
+
+- (void)setIncludesThreeByteManufacturerID:(BOOL)includesThreeByteManufacturerID
+{
+    if (![[self class] isMutable]) return MIKMIDI_RAISE_MUTATION_ATTEMPT_EXCEPTION;
+    _includesThreeByteManufacturerID = includesThreeByteManufacturerID;
+    self.manufacturerID = self.manufacturerID;
 }
 
 - (BOOL)isUniversal
@@ -226,6 +239,7 @@ uint8_t const kMIKMIDISysexEndDelimiter = 0xF7;
 
 // One of the super classes already implements a getter *and* setter for these. @dynamic keeps the compiler happy.
 @dynamic manufacturerID;
+@dynamic includesThreeByteManufacturerID;
 @dynamic sysexChannel;
 @dynamic sysexData;
 @dynamic timestamp;


### PR DESCRIPTION
Fixes #304 