### PR TITLE
Added general NotificationCenter notifications for MIDI Device and Entity changes

### DIFF
--- a/Source/MIKMIDIDeviceManager.m
+++ b/Source/MIKMIDIDeviceManager.m
@@ -29,10 +29,12 @@ NSString * const MIKMIDIDeviceWasAddedNotification = @"MIKMIDIDeviceWasAddedNoti
 NSString * const MIKMIDIDeviceWasRemovedNotification = @"MIKMIDIDeviceWasRemovedNotification";
 NSString * const MIKMIDIVirtualEndpointWasAddedNotification = @"MIKMIDIVirtualEndpointWasAddedNotification";
 NSString * const MIKMIDIVirtualEndpointWasRemovedNotification = @"MIKMIDIVirtualEndpointWasRemovedNotification";
+NSString * const MIKMIDIDevicePropertyWasChangedNotification = @"MIKMIDIDevicePropertyWasChangedNotification";
 
 
 // Notification Keys
 NSString * const MIKMIDIDeviceKey = @"MIKMIDIDeviceKey";
+NSString * const MIKMIDIDevicePropertyKey = @"MIKMIDIDevicePropertyKey";
 NSString * const MIKMIDIEndpointKey = @"MIKMIDIEndpointKey";
 
 static MIKMIDIDeviceManager *sharedDeviceManager;
@@ -217,7 +219,10 @@ static MIKMIDIDeviceManager *sharedDeviceManager;
 	switch (notification->objectType) {
 		case kMIDIObjectType_Device: {
 			
-			if (![changedProperty isEqualToString:(__bridge NSString *)kMIDIPropertyOffline]) break;
+			if (![changedProperty isEqualToString:(__bridge NSString *)kMIDIPropertyOffline]) {
+				[nc postNotificationName:MIKMIDIDevicePropertyWasChangedNotification object:self userInfo:@{MIKMIDIDevicePropertyKey : changedProperty}];
+				break;
+			}
 			
 			MIKMIDIDevice *changedObject = [MIKMIDIDevice MIDIObjectWithObjectRef:notification->object];
 			if (!changedObject) break;

--- a/Source/MIKMIDIDeviceManager.m
+++ b/Source/MIKMIDIDeviceManager.m
@@ -30,12 +30,13 @@ NSString * const MIKMIDIDeviceWasRemovedNotification = @"MIKMIDIDeviceWasRemoved
 NSString * const MIKMIDIVirtualEndpointWasAddedNotification = @"MIKMIDIVirtualEndpointWasAddedNotification";
 NSString * const MIKMIDIVirtualEndpointWasRemovedNotification = @"MIKMIDIVirtualEndpointWasRemovedNotification";
 NSString * const MIKMIDIDevicePropertyWasChangedNotification = @"MIKMIDIDevicePropertyWasChangedNotification";
-
+NSString * const MIKMIDIEntityWasChangedNotification = @"MIKMIDIEntityWasChangedNotification";
 
 // Notification Keys
 NSString * const MIKMIDIDeviceKey = @"MIKMIDIDeviceKey";
 NSString * const MIKMIDIDevicePropertyKey = @"MIKMIDIDevicePropertyKey";
 NSString * const MIKMIDIEndpointKey = @"MIKMIDIEndpointKey";
+NSString * const MIKMIDIEntityKey = @"MIKMIDIEntityKey";
 
 static MIKMIDIDeviceManager *sharedDeviceManager;
 
@@ -270,6 +271,9 @@ static MIKMIDIDeviceManager *sharedDeviceManager;
 				[nc postNotificationName:MIKMIDIVirtualEndpointWasRemovedNotification object:self userInfo:@{MIKMIDIEndpointKey : changedObject}];
 			}
 		}
+			break;
+		case kMIDIObjectType_Entity:
+			[nc postNotificationName:MIKMIDIEntityWasChangedNotification object:self userInfo:@{MIKMIDIEntityKey : changedProperty}];
 			break;
 		default:
 			break;


### PR DESCRIPTION
These new notifications can be used to determine changes made to the IAC device and MIDI Network Session destinations, accessed through Audio/MIDI Setup.

In response to issue reported at https://github.com/mixedinkey-opensource/MIKMIDI/issues/319.