### PR TITLE
Issue #324: Add NSCopying conformance to MIKMIDISequence

### DIFF
--- a/Framework/MIKMIDI Tests/MIKMIDISequenceTests.m
+++ b/Framework/MIKMIDI Tests/MIKMIDISequenceTests.m
@@ -189,6 +189,31 @@ static void *MIKMIDISequenceTestsKVOContext = &MIKMIDISequenceTestsKVOContext;
 	[self.sequence setTimeSignature:MIKMIDITimeSignatureMake(2, 4) atTimeStamp:0];
 }
 
+- (void)testCopyingSequence
+{
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSURL *testMIDIFileURL = [bundle URLForResource:@"Parallax-Loader" withExtension:@"mid"];
+    NSError *error = nil;
+    MIKMIDISequence *sequence = [MIKMIDISequence sequenceWithFileAtURL:testMIDIFileURL convertMIDIChannelsToTracks:NO error:&error];
+    XCTAssertNotNil(sequence);
+
+    MIKMIDISequence *copiedSequence = [sequence copy];
+    XCTAssertNotIdentical(sequence, copiedSequence, @"Copied sequence was same instance as original");
+    XCTAssertEqual(sequence.tracks.count, copiedSequence.tracks.count);
+    XCTAssertEqual(sequence.length, copiedSequence.length);
+    XCTAssertEqual(sequence.durationInSeconds, copiedSequence.durationInSeconds);
+
+    NSMutableArray *allTracks = [NSMutableArray arrayWithObject:sequence.tempoTrack];
+    [allTracks addObjectsFromArray:sequence.tracks];
+    NSMutableArray *allCopiedTracks = [NSMutableArray arrayWithObject:copiedSequence.tempoTrack];
+    [allCopiedTracks addObjectsFromArray:copiedSequence.tracks];
+    for (NSUInteger i=0; i<allTracks.count; i++) {
+        MIKMIDITrack *track = allTracks[i];
+        MIKMIDITrack *copiedTrack = allCopiedTracks[i];
+        XCTAssertNotIdentical(track, copiedTrack, @"Copied track was same instance as original");
+        XCTAssertEqualObjects(track.events, copiedTrack.events);
+    }
+}
 #pragma mark - KVO
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context

--- a/Framework/MIKMIDI Tests/MIKMIDISequenceTests.m
+++ b/Framework/MIKMIDI Tests/MIKMIDISequenceTests.m
@@ -214,6 +214,19 @@ static void *MIKMIDISequenceTestsKVOContext = &MIKMIDISequenceTestsKVOContext;
         XCTAssertEqualObjects(track.events, copiedTrack.events);
     }
 }
+
+- (void)testCopyingSequencePerformance
+{
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSURL *testMIDIFileURL = [bundle URLForResource:@"Parallax-Loader" withExtension:@"mid"];
+    NSError *error = nil;
+    MIKMIDISequence *sequence = [MIKMIDISequence sequenceWithFileAtURL:testMIDIFileURL convertMIDIChannelsToTracks:NO error:&error];
+    XCTAssertNotNil(sequence);
+    [self measureBlock:^{
+        [sequence copy];
+    }];
+}
+
 #pragma mark - KVO
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context

--- a/Framework/MIKMIDI.xcodeproj/xcshareddata/xcbaselines/9D4DF1391AAB57430065F004.xcbaseline/3C4B92F8-480E-48B6-B83C-917B91EB0717.plist
+++ b/Framework/MIKMIDI.xcodeproj/xcshareddata/xcbaselines/9D4DF1391AAB57430065F004.xcbaseline/3C4B92F8-480E-48B6-B83C-917B91EB0717.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>MIKMIDISequenceTests</key>
+		<dict>
+			<key>testCopyingSequencePerformance</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.066800</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testMIDIFileReadPerformance</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.056909</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Framework/MIKMIDI.xcodeproj/xcshareddata/xcbaselines/9D4DF1391AAB57430065F004.xcbaseline/C1C9286E-763A-4210-B3E7-DF2205A6AA20.plist
+++ b/Framework/MIKMIDI.xcodeproj/xcshareddata/xcbaselines/9D4DF1391AAB57430065F004.xcbaseline/C1C9286E-763A-4210-B3E7-DF2205A6AA20.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.05</real>
+					<real>0.050000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -21,11 +21,11 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1.09</real>
+					<real>1.090000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Nov 9, 2017, 3:28:48 PM</string>
 					<key>maxPercentRelativeStandardDeviation</key>
-					<real>25</real>
+					<real>25.000000</real>
 				</dict>
 			</dict>
 		</dict>
@@ -36,11 +36,11 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.253</real>
+					<real>0.253000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Nov 9, 2017, 3:28:56 PM</string>
 					<key>maxPercentRelativeStandardDeviation</key>
-					<real>10</real>
+					<real>10.000000</real>
 				</dict>
 			</dict>
 		</dict>

--- a/Framework/MIKMIDI.xcodeproj/xcshareddata/xcbaselines/9D4DF1391AAB57430065F004.xcbaseline/C98DAFC3-AC32-4BFB-848B-A1B88CB141E1.plist
+++ b/Framework/MIKMIDI.xcodeproj/xcshareddata/xcbaselines/9D4DF1391AAB57430065F004.xcbaseline/C98DAFC3-AC32-4BFB-848B-A1B88CB141E1.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1.6332</real>
+					<real>1.633200</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Nov 4, 2019 at 10:50:41 PM</string>
 				</dict>

--- a/Framework/MIKMIDI.xcodeproj/xcshareddata/xcbaselines/9D4DF1391AAB57430065F004.xcbaseline/Info.plist
+++ b/Framework/MIKMIDI.xcodeproj/xcshareddata/xcbaselines/9D4DF1391AAB57430065F004.xcbaseline/Info.plist
@@ -4,6 +4,30 @@
 <dict>
 	<key>runDestinationsByUUID</key>
 	<dict>
+		<key>3C4B92F8-480E-48B6-B83C-917B91EB0717</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M1 Max</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>modelCode</key>
+				<string>MacBookPro18,2</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+		</dict>
 		<key>C1C9286E-763A-4210-B3E7-DF2205A6AA20</key>
 		<dict>
 			<key>localComputer</key>

--- a/Source/MIKMIDIEvent.h
+++ b/Source/MIKMIDIEvent.h
@@ -154,6 +154,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithTimeStamp:(MusicTimeStamp)timeStamp midiEventType:(MIKMIDIEventType)eventType data:(nullable NSData *)data NS_DESIGNATED_INITIALIZER;
 
 /**
+ * Compares two events for equality.
+ * @param otherEvent The event with which to compare the receiver.
+ *
+ * @return YES if the events have the same type, timeStamp, and data, NO otherwise.
+ */
+- (BOOL)isEqualToEvent:(MIKMIDIEvent *)otherEvent;
+
+/**
  *  The MIDI event type.
  */
 @property (nonatomic, readonly) MIKMIDIEventType eventType;

--- a/Source/MIKMIDIEvent.m
+++ b/Source/MIKMIDIEvent.m
@@ -85,14 +85,18 @@ static NSMutableSet *registeredMIKMIDIEventSubclasses;
 
 #pragma mark - Equality
 
+- (BOOL)isEqualToEvent:(MIKMIDIEvent *)otherEvent
+{
+    if (otherEvent.eventType != self.eventType) return NO;
+    return (self.timeStamp == otherEvent.timeStamp && [self.internalData isEqualToData:otherEvent.internalData]);
+}
+
 - (BOOL)isEqual:(id)object
 {
 	if (object == self) return YES;
 	if (![object isKindOfClass:[MIKMIDIEvent class]]) return NO;
-	
-	MIKMIDIEvent *otherEvent = (MIKMIDIEvent *)object;
-	if (otherEvent.eventType != self.eventType) return NO;
-	return (self.timeStamp == otherEvent.timeStamp && [self.internalData isEqualToData:otherEvent.internalData]);
+
+    return [self isEqualToEvent:(MIKMIDIEvent *)object];
 }
 
 - (NSUInteger)hash

--- a/Source/MIKMIDISequence.h
+++ b/Source/MIKMIDISequence.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @see MIKMIDITrack
  *  @see MIKMIDISequencer
  */
-@interface MIKMIDISequence : NSObject
+@interface MIKMIDISequence : NSObject <NSCopying>
 
 /**
  *  Creates and initializes a new instance of MIKMIDISequence.

--- a/Source/MIKMIDITrack.m
+++ b/Source/MIKMIDITrack.m
@@ -557,9 +557,8 @@
 
 - (void)addInternalEvents:(NSSet *)events
 {
-	for (MIKMIDIEvent *event in events) {
-		[self addInternalEventsObject:[event copy]];
-	}
+    [self.internalEvents addObjectsFromArray:[events allObjects]];
+    self.sortedEventsCache = nil;
 }
 
 - (void)removeInternalEventsObject:(MIKMIDIEvent *)event


### PR DESCRIPTION
This PR adds a copy implementation to MIKMIDISequence, along with associated tests, and a fix for a performance issue revealed by this new feature. Note that copies of MIKMIDISequence are always mutable, because MIKMIDISequence itself is always mutable.

- Issue #324: Add specialized -isEqual: method to MIKMIDIEvent
- Issue #324: Implement NSCopying in MIKMIDISequence and add associated test
- Issue #324: Improve performance of copying events into a track, along with performance test for sequence copying and updated baselines
