### PR TITLE
Issue #316: MIDI To Audio example fails after choosing Midi file

### DIFF
--- a/Examples/macOS/MIDI To Audio/Sources/MIKMIDIToAudioExporter.m
+++ b/Examples/macOS/MIDI To Audio/Sources/MIKMIDIToAudioExporter.m
@@ -69,7 +69,7 @@
 	MIKMIDISequence *sequence = [MIKMIDISequence sequenceWithFileAtURL:self.midiFileURL error:&error];
 	if (!sequence) return [self finishWithError:error];
 	
-	self.synthesizer = [[MIKOfflineMIDISynthesizer alloc] init];
+    self.synthesizer = [[MIKOfflineMIDISynthesizer alloc] initWithError:&error];
 	self.synthesizer.tracks = sequence.tracks;
 	self.synthesizer.tempo = [sequence tempoAtTimeStamp:0];
 	

--- a/Examples/macOS/MIDI To Audio/Sources/MIKOfflineMIDISynthesizer.m
+++ b/Examples/macOS/MIDI To Audio/Sources/MIKOfflineMIDISynthesizer.m
@@ -104,7 +104,16 @@ AudioStreamBasicDescription LPCMASBD(void)
 	return self;
 }
 
-- (BOOL)setupAUGraph
+- (instancetype)initWithError:(NSError *__autoreleasing  _Nullable *)error
+{
+	self = [super initWithError:error];
+	if (self) {
+		_midiClock = [MIKMIDIClock clock];
+	}
+	return self;
+}
+
+- (BOOL)setupAUGraphWithError:(NSError **)error
 {
 	AUGraph graph;
 	OSStatus err = 0;


### PR DESCRIPTION
setupAUGraph was not getting called because of a deprecation in the underlying API. self._midiClock was null so rendering looped forever until I fixed to be set in initWithError