### PR TITLE
Cleared "A function declaration without a prototype is deprecated in all versions of C" compiler warnings

### DIFF
--- a/Source/MIKMIDIClock.m
+++ b/Source/MIKMIDIClock.m
@@ -360,7 +360,7 @@ static void releaseHistoricalClocks(MIKMIDIClock *self)
 
 #pragma mark - Functions
 
-Float64 MIKMIDIClockSecondsPerMIDITimeStamp()
+Float64 MIKMIDIClockSecondsPerMIDITimeStamp(void)
 {
     static Float64 secondsPerMIDITimeStamp;
     static dispatch_once_t onceToken;

--- a/Source/MIKMIDIUtilities.m
+++ b/Source/MIKMIDIUtilities.m
@@ -150,7 +150,7 @@ NSInteger MIKMIDIStandardLengthOfMessageForCommandType(MIKMIDICommandType comman
 	return result;
 }
 
-MIDITimeStamp MIKMIDIGetCurrentTimeStamp()
+MIDITimeStamp MIKMIDIGetCurrentTimeStamp(void)
 {
 	return mach_absolute_time();
 }


### PR DESCRIPTION
In response to https://github.com/mixedinkey-opensource/MIKMIDI/issues/353.